### PR TITLE
Added support for retina images using srcset in img tag.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -4905,6 +4905,12 @@ this.prependChild( 'info', 'myElement' );
 
                 self._layers[index].innerHTML = self.getData().layer || '';
 
+                // Set srcset in img tag for responsive retina images.
+                if (data.srcset) {
+                    $( image.image ).attr( 'srcset', data.srcset );
+                    $( image.image ).attr( 'sizes', image.width+"px" );
+                }
+
                 self.trigger($.extend(evObj, {
                     type: Galleria.LOADFINISH
                 }));
@@ -5150,6 +5156,12 @@ this.prependChild( 'info', 'myElement' );
             self._scaleImage( next, {
 
                 complete: function( next ) {
+
+                    // Set srcset in img tag for responsive retina images.
+                    if (data.srcset) {
+                        $( next.image ).attr( 'srcset', data.srcset );
+                        $( next.image ).attr( 'sizes', next.width+"px" );
+                    }
 
                     // toggle low quality for IE
                     if ( 'image' in active ) {

--- a/src/galleria.js
+++ b/src/galleria.js
@@ -4908,7 +4908,12 @@ this.prependChild( 'info', 'myElement' );
                 // Set srcset in img tag for responsive retina images.
                 if (data.srcset) {
                     $( image.image ).attr( 'srcset', data.srcset );
-                    $( image.image ).attr( 'sizes', image.width+"px" );
+                    if (image.width) {
+                        $( image.image ).attr( 'sizes', image.width+"px" );
+                    } else {
+                        // We don't know the size of the image yet, but it can't be wider than the viewport
+                        $( image.image ).attr( 'sizes', "100wv" );
+                    }
                 }
 
                 self.trigger($.extend(evObj, {


### PR DESCRIPTION
- Used by adding srcset string when pushing images to gallery.

Example:
```javascript
slides.push({
	thumb: image.getThumbnailUrl(),
	image: image.getWebImageUrl(),
	big: image.getSlideUrl(),
	title: gallery.getName(),
	description: image.getDescription(),
	srcset: image.calculateSrcSet()
});
```

Results in: 
```html
<img width="921" height="691" style="image-rendering: optimizequality; display: block; opacity: 1; min-width: 0px; min-height: 0px; max-width: none; max-height: none; transform: translate3d(0px, 0px, 0px); width: 921px; height: 691px; position: absolute; top: 0px; left: 490px; cursor: pointer;" src="slideshow/2014-10_062.jpg" srcset="thumbnails/thumb_2014-10_062.jpg 200w, pics/2014-10_062.jpg 800w, slideshow/2014-10_062.jpg 1600w, 2048x2048/2014-10_062.jpg 2048w, 3840x2160/2014-10_062.jpg 2880w" sizes="921px">
```
This will tell the browser that the image will be rendered at 921px width (initially), calculated by the Galleria scaler, and that there is a set of sources available. On my Nexus 9, it will choose the 2048w image.