### PR TITLE
Add safety operators when no thumbnails exist

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -5090,7 +5090,7 @@ this.prependChild( 'info', 'myElement' );
                     type: Galleria.IMAGE,
                     index: queue.index,
                     imageTarget: next.image,
-                    thumbTarget: thumb.image,
+                    thumbTarget: thumb ? thumb.image : null,
                     galleriaData: data
                 });
 
@@ -5122,10 +5122,12 @@ this.prependChild( 'info', 'myElement' );
         next.isIframe = data.iframe && !data.image;
 
         // add active classes
-        $( self._thumbnails[ queue.index ].container )
+        if ( self._thumbnails[ queue.index ] ) {
+            $( self._thumbnails[ queue.index ].container )
             .addClass( 'active' )
             .siblings( '.active' )
             .removeClass( 'active' );
+        }
 
         // trigger the LOADSTART event
         self.trigger( {
@@ -5134,7 +5136,7 @@ this.prependChild( 'info', 'myElement' );
             index: queue.index,
             rewind: queue.rewind,
             imageTarget: next.image,
-            thumbTarget: thumb.image,
+            thumbTarget: thumb ? thumb.image : null,
             galleriaData: data
         });
 


### PR DESCRIPTION
Better protection for running .load(data) when data
does not contain thumbnails

To prevent console errors like this...
Uncaught TypeError: Cannot read property 'container' of undefinedgalleria.js:5125 Galleria._showgalleria.js:4944 Galleria.showgalleria.js:3780 Galleria._run.Utils.wait.successgalleria.js:719 Utils.wait.fn