### PR TITLE
Fix mobile device manipulation

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -4076,6 +4076,45 @@ Galleria.prototype = {
             self._parseData( function() {
                 self._createThumbnails( args );
             });
+            if (self._options.swipe) {
+                var slidesLength = (self.getDataLength() - 1),
+                    $images = self.$( 'images' ).width( slidesLength * self._stageWidth ),
+                    image = new Galleria.Picture(),
+                    data = self.getData(slidesLength);
+
+                $( image.container ).css({
+                    position: 'absolute',
+                    top: 0,
+                    left: self._stageWidth*(slidesLength)
+                }).prepend( self._layers[slidesLength] = $( Utils.create('galleria-layer') ).css({
+                    position: 'absolute',
+                    top:0, left:0, right:0, bottom:0,
+                    zIndex:2
+                })[0] ).appendTo( $images );
+
+                if( data.video ) {
+                    _playIcon( image.container );
+                }
+
+                self._controls.slides.push(image);
+
+                var frame = new Galleria.Picture();
+                frame.isIframe = true;
+
+                $( frame.container ).attr('class', 'galleria-frame').css({
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    zIndex: 4,
+                    background: '#000',
+                    display: 'none'
+                }).appendTo( image.container );
+
+                self._controls.frames.push(frame);
+
+                self.finger.setup();
+            }
+
         }, 2);
         return self;
     },


### PR DESCRIPTION
Fixed issue https://github.com/aino/galleria/issues/315

I copied over and modified some code from the internal _run() function to the push() function which fixed this issue for me. Basically what this does is add the pushed image(s) to the _controls.slides array if swipe is enabled. This of course assumes you are using the galleria.push() method to push additional images to the Slideshow after the Slideshow is ready.