### PR TITLE
Worked around iOS mobile Safari browser bug which leaks memory…

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -6157,11 +6157,18 @@ Galleria.Picture.prototype = {
     */
 
     preload: function( src ) {
-        $( new Image() ).load((function(src, cache) {
-            return function() {
-                cache[ src ] = src;
-            };
-        }( src, this.cache ))).attr( 'src', src );
+        // Create a new Image; register a callback for onload
+        // that adds an entry in the Galleria.Picture cache 
+        // indicating that src is already loaded; then set
+        // the 'src' attribute to actually start loading.
+        $( new Image() ).load(function() {
+            // Add to cache since loading of src has completed
+            Galleria.Picture.prototype.cache[ src ] = 1;
+            // Clear out the 'src' attribute when done to work around a mobile Safari 
+            // bug that results in a memory leak if an Image object's 'src' is
+            // left referencing an image.
+            this.src = '';
+        }).attr( 'src', src );
     },
 
     /**
@@ -6314,6 +6321,9 @@ Galleria.Picture.prototype = {
                 };
             }( this, callback, src ));
 
+        // http://stackoverflow.com/a/3993689/5299483 - clear out 'src' attribute
+        // to free mobile Safari memory
+        $container.find('img').attr('src', '');
         // remove any previous images
         $container.find( 'iframe,img' ).remove();
 


### PR DESCRIPTION
if <img> tags are removed from the DOM without having their 'src' attribute first set to ''.

I love the library and used it to build a personal photo gallery with > 600 images in native iPad format (2048x1536).  It would cycle through around 115 images and then Safari would crash.  I did some digging and found a known issue with a solution (see comments in my patch).

The patched code seems to be working fine: I have been running my single-page photo web app for hours and it has been cycling through the images without crashing. 

Just thought you might be interested in the fix.

Cheers,

-Dane